### PR TITLE
Исправил https://github.com/vvip-68/GyverPanelWiFi/issues/139

### DIFF
--- a/firmware/GyverPanelWiFi_v1.10/GyverPanelWiFi_v1.10.ino
+++ b/firmware/GyverPanelWiFi_v1.10/GyverPanelWiFi_v1.10.ino
@@ -6,8 +6,8 @@
 // https://AlexGyver.ru/
 //
 // Дополнительные ссылки для Менеджера плат ESP8266 и ESP32 в Файл -> Настройки
-// http://arduino.esp8266.com/stable/pspackage_esp8266com_index.json
-// https://raw.githubuserconteenumnt.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+// https://raw.githubusercontent.com/esp8266/esp8266.github.io/master/stable/package_esp8266com_index.json
+// https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
 
 // Внимание!!! 
 // На версии ядра ESP8266 v3.0.0 и FastLED 3.4 работать не будет! 


### PR DESCRIPTION
Поправил неправильные ссылки для менеджера плат в [GyverPanelWiFi_v1.10.ino](https://github.com/vvip-68/GyverPanelWiFi/blob/60181970cdd0866d0bea0ef5f4420695d4ad3682/firmware/GyverPanelWiFi_v1.10/GyverPanelWiFi_v1.10.ino#L10)